### PR TITLE
Add C++ side of cube-host communication

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,3 +4,21 @@ new_http_archive(
   urls = ["https://developer.arm.com/-/media/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf.tar.xz?revision=51f3ba22-a569-4dda-aedc-7988690c3c17&ln=en"],
   strip_prefix = "gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf"
 )
+
+# proto_library, cc_proto_library, and java_proto_library rules implicitly
+# depend on @com_google_protobuf for protoc and proto runtimes.
+# This statement defines the @com_google_protobuf repo.
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
+    strip_prefix = "protobuf-3.5.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
+)
+
+new_http_archive(
+  name = "gtest",
+  url = "https://github.com/google/googletest/archive/release-1.8.0.zip",
+  sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",
+  build_file = "gtest.BUILD",
+  strip_prefix = "googletest-release-1.8.0",
+)

--- a/apps/libmc/BUILD
+++ b/apps/libmc/BUILD
@@ -1,7 +1,5 @@
 cc_library(
-  name = "mc",
-  srcs = glob(["*.cc"]),
-  hdrs = glob(["*.h"]),
-  deps = ["//apps/libmc/graphics"],
-  visibility = ["//visibility:public"],
+  name = "constants",
+  hdrs = ["constants.h"],
+  visibility = ["//apps/libmc:__subpackages__"],
 )

--- a/apps/libmc/constants.h
+++ b/apps/libmc/constants.h
@@ -1,0 +1,28 @@
+#ifndef LIBMC_CONSTANTS_H_
+#define LIBMC_CONSTANTS_H_
+
+#include <stdint.h>
+
+namespace libmc {
+namespace constants {
+
+struct Simulator {
+  // The device to use for serial communication with the simulator host.
+  const char *Device;
+  // The baud rate to use for communication.
+  uint32_t BaudRate;
+
+  // The maximum packet size to allow. Increasing this allows for more
+  // flexibility but increases the memory burden.
+  uint32_t MaxPacketSize;
+};
+
+constexpr Simulator kSimulator = {"/dev/vcube_ser", 115200, 1024};
+
+// The buffer size should be even for COWS to work reliably.
+static_assert(kSimulator.MaxPacketSize % 2 == 0);
+
+}  // namespace constants
+}  // namespace libmc
+
+#endif  // LIBMC_CONSTANTS_H_

--- a/apps/libmc/core/BUILD
+++ b/apps/libmc/core/BUILD
@@ -1,0 +1,7 @@
+cc_library(
+  name = "core",
+  srcs = glob(["*.cc"]),
+  hdrs = glob(["*.h"]),
+  deps = ["//apps/libmc/graphics"],
+  visibility = ["//visibility:public"],
+)

--- a/apps/libmc/core/neighborhood.cc
+++ b/apps/libmc/core/neighborhood.cc
@@ -3,6 +3,7 @@
 // TODO (danielp): Fill in stubs.
 
 namespace libmc {
+namespace core {
 
 const Connections &Neighborhood::GetConnections() { return connections_; }
 
@@ -19,4 +20,5 @@ void Neighborhood::WaitForEvent() {}
 
 void PollForEvent() {}
 
+}  // namespace core
 }  // namespace libmc

--- a/apps/libmc/core/neighborhood.h
+++ b/apps/libmc/core/neighborhood.h
@@ -1,9 +1,10 @@
-#ifndef LIBMC_NEIGHBORHOOD_H_
-#define LIBMC_NEIGHBORHOOD_H_
+#ifndef LIBMC_CORE_NEIGHBORHOOD_H_
+#define LIBMC_CORE_NEIGHBORHOOD_H_
 
 #include <stdint.h>
 
 namespace libmc {
+namespace core {
 
 // Represents the connection configuration of a cube.
 struct Connections {
@@ -76,6 +77,7 @@ class Neighborhood {
   Connections connections_;
 };
 
+}  // namespace core
 }  // namespace libmc
 
-#endif  // LIBMC_NEIGHBORHOOD_H_
+#endif  // LIBMC_CORE_NEIGHBORHOOD_H_

--- a/apps/libmc/sim/BUILD
+++ b/apps/libmc/sim/BUILD
@@ -1,6 +1,8 @@
 cc_library(
   name = "sim",
-  srcs = glob(["*.cc"], exclude=["*_test.cc"]),
+  srcs = glob(["*.cc"]),
   hdrs = glob(["*.h"]),
+  deps = ["//apps/libmc:constants",
+          "@com_google_protobuf//:protobuf_lite"],
   visibility = ["//apps/libmc:__subpackages__"],
 )

--- a/apps/libmc/sim/BUILD
+++ b/apps/libmc/sim/BUILD
@@ -1,0 +1,6 @@
+cc_library(
+  name = "sim",
+  srcs = glob(["*.cc"], exclude=["*_test.cc"]),
+  hdrs = glob(["*.h"]),
+  visibility = ["//apps/libmc:__subpackages__"],
+)

--- a/apps/libmc/sim/cows.cc
+++ b/apps/libmc/sim/cows.cc
@@ -5,15 +5,15 @@
 namespace libmc {
 namespace sim {
 
-void CowsStuff(uint16_t *buffer, uint16_t length) {
-  assert(length >= 2 && "Length must be at least 2.");
+void Cows::CowsStuff(uint16_t *buffer, uint16_t length) {
+  assert(length >= 1 && "Length must be at least 1.");
 
   uint16_t *const data_end = buffer + length;
   uint16_t *last_zero = data_end;
 
   // Make a single pass backwards to remove all the zeroes.
-  // Ignore the first two words, which will be filled in by us later.
-  for (uint16_t *word = data_end - 1; word >= buffer + 2; --word) {
+  // Ignore the first word, which will be filled in by us later.
+  for (uint16_t *word = data_end - 1; word >= buffer + 1; --word) {
     if (!(*word)) {
       // Replace the zero.
       *word = last_zero - word;
@@ -21,17 +21,15 @@ void CowsStuff(uint16_t *buffer, uint16_t length) {
     }
   }
 
-  // Fill in the overhead byte and packet separator.
-  buffer[0] = 0;
-  buffer[1] = last_zero - (buffer + 1);
+  // Fill in the overhead byte.
+  buffer[0] = last_zero - (buffer + 1);
 }
 
-void CowsUnstuff(uint16_t *buffer, uint16_t length) {
-  assert(length >= 2 && "Length must be at least 2.");
-  assert(!buffer[0] && "Got invalid packet separator.");
+void Cows::CowsUnstuff(uint16_t *buffer, uint16_t length) {
+  assert(length >= 1 && "Length must be at least 1.");
 
-  // Location of first zero is notated in word 1.
-  uint16_t *next_zero = buffer + 1 + buffer[1];
+  // Location of first zero is notated in word 0.
+  uint16_t *next_zero = buffer + 1 + buffer[0];
 
   // Make a single forward pass to replace all the zeroes.
   while (next_zero < buffer + length) {

--- a/apps/libmc/sim/cows.cc
+++ b/apps/libmc/sim/cows.cc
@@ -1,0 +1,45 @@
+#include "cows.h"
+
+#include <assert.h>
+
+namespace libmc {
+namespace sim {
+
+void CowsStuff(uint16_t *buffer, uint16_t length) {
+  assert(length >= 2 && "Length must be at least 2.");
+
+  uint16_t *const data_end = buffer + length;
+  uint16_t *last_zero = data_end;
+
+  // Make a single pass backwards to remove all the zeroes.
+  // Ignore the first two words, which will be filled in by us later.
+  for (uint16_t *word = data_end - 1; word >= buffer + 2; --word) {
+    if (!(*word)) {
+      // Replace the zero.
+      *word = last_zero - word;
+      last_zero = word;
+    }
+  }
+
+  // Fill in the overhead byte and packet separator.
+  buffer[0] = 0;
+  buffer[1] = last_zero - (buffer + 1);
+}
+
+void CowsUnstuff(uint16_t *buffer, uint16_t length) {
+  assert(length >= 2 && "Length must be at least 2.");
+  assert(!buffer[0] && "Got invalid packet separator.");
+
+  // Location of first zero is notated in word 1.
+  uint16_t *next_zero = buffer + 1 + buffer[1];
+
+  // Make a single forward pass to replace all the zeroes.
+  while (next_zero < buffer + length) {
+    const uint16_t move_forward = *next_zero;
+    *next_zero = 0;
+    next_zero += move_forward;
+  }
+}
+
+}  // namespace sim
+}  // namespace libmc

--- a/apps/libmc/sim/cows.h
+++ b/apps/libmc/sim/cows.h
@@ -1,0 +1,36 @@
+#ifndef MYELIN_NET_COWS_H_
+#define MYELIN_NET_COWS_H_
+
+#include <stdint.h>
+
+// Defines an implementation of a variation of Consistent Overhead Byte Stuffing
+// (COBS) which operates on the basis of words (2-byte) instead of bytes. This
+// allows for lower overhead when stuffing long messages.
+
+namespace libmc {
+namespace sim {
+
+// Stuffs a buffer in-place. It will automatically add the 0 packet divider and
+// overhead word at the beginning of the buffer, so these first two words should
+// not contain actual data.
+// Args:
+//  buffer: The buffer to stuff.
+//  length: The usable length of the buffer. Note that the COWS implentation
+//          reserves the two words at the start of the buffer, so length should
+//          be at least 2.
+void CowsStuff(uint16_t *buffer, uint16_t length);
+
+// Un-stuffs a buffer in-place. It expects the first two words to be the 0
+// packet divider and overhead word. These will consequently be unchanged in the
+// unstuffed version.
+// Args:
+//  buffer: The buffer stuffed with CowsStuff() to be un-stuffed.
+//  length: The usable length of the buffer. Note that the two bytes at the
+//          beginning of the buffer will not be changed, so length should be at
+//          least 2.
+void CowsUnstuff(uint16_t *buffer, uint16_t length);
+
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // MYELIN_NET_COWS_H_

--- a/apps/libmc/sim/cows.h
+++ b/apps/libmc/sim/cows.h
@@ -1,36 +1,23 @@
-#ifndef MYELIN_NET_COWS_H_
-#define MYELIN_NET_COWS_H_
+#ifndef LIBMC_SIM_COWS_H_
+#define LIBMC_SIM_COWS_H_
 
 #include <stdint.h>
 
-// Defines an implementation of a variation of Consistent Overhead Byte Stuffing
-// (COBS) which operates on the basis of words (2-byte) instead of bytes. This
-// allows for lower overhead when stuffing long messages.
+#include "cows_interface.h"
 
 namespace libmc {
 namespace sim {
 
-// Stuffs a buffer in-place. It will automatically add the 0 packet divider and
-// overhead word at the beginning of the buffer, so these first two words should
-// not contain actual data.
-// Args:
-//  buffer: The buffer to stuff.
-//  length: The usable length of the buffer. Note that the COWS implentation
-//          reserves the two words at the start of the buffer, so length should
-//          be at least 2.
-void CowsStuff(uint16_t *buffer, uint16_t length);
-
-// Un-stuffs a buffer in-place. It expects the first two words to be the 0
-// packet divider and overhead word. These will consequently be unchanged in the
-// unstuffed version.
-// Args:
-//  buffer: The buffer stuffed with CowsStuff() to be un-stuffed.
-//  length: The usable length of the buffer. Note that the two bytes at the
-//          beginning of the buffer will not be changed, so length should be at
-//          least 2.
-void CowsUnstuff(uint16_t *buffer, uint16_t length);
+// Defines an implementation of a variation of Consistent Overhead Byte Stuffing
+// (COBS) which operates on the basis of words (2-byte) instead of bytes. This
+// allows for lower overhead when stuffing long messages.
+class Cows : public CowsInterface {
+ public:
+  virtual void CowsStuff(uint16_t *buffer, uint16_t length);
+  virtual void CowsUnstuff(uint16_t *buffer, uint16_t length);
+};
 
 }  // namespace sim
 }  // namespace libmc
 
-#endif  // MYELIN_NET_COWS_H_
+#endif  // LIBMC_SIM_COWS_H_

--- a/apps/libmc/sim/cows_interface.h
+++ b/apps/libmc/sim/cows_interface.h
@@ -1,0 +1,37 @@
+#ifndef LIBMC_SIM_COWS_INTERFACE_H_
+#define LIBMC_SIM_COWS_INTERFACE_H_
+
+#include <stdint.h>
+
+namespace libmc {
+namespace sim {
+
+// Common interface for COWS.
+class CowsInterface {
+ public:
+  virtual ~CowsInterface() = default;
+
+  // Stuffs a buffer in-place. It will automatically add the overhead word at
+  // the beginning of the buffer, so this first word should not contain
+  // actual data.
+  // Args:
+  //  buffer: The buffer to stuff.
+  //  length: The usable length of the buffer. Note that the COWS implentation
+  //          reserves one word at the start of the buffer, so length should
+  //          be at least 1.
+  virtual void CowsStuff(uint16_t *buffer, uint16_t length) = 0;
+
+  // Un-stuffs a buffer in-place. It expects the first word to be the overhead
+  // word. This will consequently be unchanged in the unstuffed version.
+  // Args:
+  //  buffer: The buffer stuffed with CowsStuff() to be un-stuffed.
+  //  length: The usable length of the buffer. Note that the one word at the
+  //          beginning of the buffer will not be changed, so length should be at
+  //          least 1.
+  virtual void CowsUnstuff(uint16_t *buffer, uint16_t length) = 0;
+};
+
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_COWS_INTERFACE_H_

--- a/apps/libmc/sim/linux_serial.cc
+++ b/apps/libmc/sim/linux_serial.cc
@@ -1,0 +1,52 @@
+#include "linux_serial.h"
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace libmc {
+namespace sim {
+
+int LinuxSerial::Open(const char *device) {
+  return open(device, O_RDWR | O_NOCTTY);
+}
+
+bool LinuxSerial::Close(int fd) {
+  return close(fd);
+}
+
+bool LinuxSerial::TcGetAttr(int fd, termios *attrs) {
+  return tcgetattr(fd, attrs) == 0;
+}
+
+bool LinuxSerial::TcSetAttr(int fd, int action, const termios *attrs) {
+  return tcsetattr(fd, action, attrs) == 0;
+}
+
+void LinuxSerial::SetOutSpeed(termios *serial, uint32_t baud) {
+  cfsetospeed(serial, static_cast<speed_t>(baud));
+}
+
+void LinuxSerial::SetInSpeed(termios *serial, uint32_t baud) {
+  cfsetispeed(serial, static_cast<speed_t>(baud));
+}
+
+void LinuxSerial::MakeRaw(termios *serial) {
+  cfmakeraw(serial);
+}
+
+void LinuxSerial::TcFlush(int fd, int options) {
+  tcflush(fd, options);
+}
+
+int32_t LinuxSerial::Read(int fd, uint8_t *message, uint32_t length) {
+  return read(fd, message, length);
+}
+
+int32_t LinuxSerial::Write(int fd, const uint8_t *message, uint32_t length) {
+  return write(fd, message, length);
+}
+
+}  // namespace sim
+}  // namespace libmc

--- a/apps/libmc/sim/linux_serial.h
+++ b/apps/libmc/sim/linux_serial.h
@@ -1,0 +1,34 @@
+#ifndef LIBMC_SIM_LINUX_SERIAL_H_
+#define LIBMC_SIM_LINUX_SERIAL_H_
+
+#include <termios.h>
+
+#include "linux_serial_interface.h"
+
+namespace libmc {
+namespace sim {
+
+// Implementation of LinuxSerialInterface that translates the functions to Linux
+// system calls.
+class LinuxSerial : public LinuxSerialInterface {
+ public:
+  virtual int Open(const char *device);
+  virtual bool Close(int fd);
+
+  virtual bool TcGetAttr(int fd, termios *attrs);
+  virtual bool TcSetAttr(int fd, int action, const termios *attrs);
+  virtual void SetOutSpeed(termios *serial, uint32_t baud);
+  virtual void SetInSpeed(termios *serial, uint32_t baud);
+
+  virtual void MakeRaw(termios *serial);
+
+  virtual void TcFlush(int fd, int options);
+
+  virtual int32_t Read(int fd, uint8_t *message, uint32_t length);
+  virtual int32_t Write(int fd, const uint8_t *message, uint32_t length);
+};
+
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_LINUX_SERIAL_H_

--- a/apps/libmc/sim/linux_serial_interface.h
+++ b/apps/libmc/sim/linux_serial_interface.h
@@ -1,0 +1,87 @@
+#ifndef LIBMC_SIM_LINUX_SERIAL_INTERFACE_H_
+#define LIBMC_SIM_LINUX_SERIAL_INTERFACE_H_
+
+#include <stdint.h>
+#include <termios.h>
+
+namespace libmc {
+namespace sim {
+
+// Defines an interface for anything that depends on the linux serial system.
+// This is meant to allow us to easily mock functions.
+class LinuxSerialInterface {
+ public:
+  virtual ~LinuxSerialInterface() = default;
+
+  // Opens a new serial device.
+  // Args:
+  //  device: The name of the device to open.
+  // Returns:
+  //  The serial device FD, or -1 on failure.
+  virtual int Open(const char *device) = 0;
+  // Closes a serial device.
+  // Args:
+  //  fd: The FD of the device to close.
+  // Returns:
+  //  True if it closed sucessfully, false otherwise.
+  virtual bool Close(int fd) = 0;
+
+  // Gets terminal attributes.
+  // Args:
+  //  fd: The FD to get attributes of.
+  //  attrs: Where to write the attributes.
+  // Returns:
+  //  True on success, false otherwise.
+  virtual bool TcGetAttr(int fd, termios *attrs) = 0;
+  // Sets terminal attributes.
+  // Args:
+  //  fd: The FD to set attributes of.
+  //  action: Constant defining optional actions to take.
+  //  attrs: The attributes to set.
+  // Returns:
+  //  True on success, false otherwise.
+  virtual bool TcSetAttr(int fd, int action, const termios *attrs) = 0;
+  // Sets the output baud rate.
+  // Args:
+  //  serial: The device to set the baud rate on.
+  //  baud: The baud rate to set.
+  virtual void SetOutSpeed(termios *serial, uint32_t baud) = 0;
+  // Sets the input baud rate.
+  // Args:
+  //  serial: The device to set the baud rate on.
+  //  baud: The baud rate to set.
+  virtual void SetInSpeed(termios *serial, uint32_t baud) = 0;
+
+  // Enables "raw" mode for a serial device.
+  // Args:
+  //  serial: The device to enable raw mode on.
+  virtual void MakeRaw(termios *serial) = 0;
+
+  // Flushes the serial port.
+  // Args:
+  //  fd: The FD of the port to flush.
+  //  options: Constant defining options.
+  virtual void TcFlush(int fd, int options) = 0;
+
+  // Reads from the serial port.
+  // Args:
+  //  fd: The FD of the port to read from.
+  //  message: Buffer to store the message in.
+  //  length: Maximum number of bytes to read.
+  // Returns:
+  //  The number of bytes that were actually read, or -1 upon error.
+  virtual int32_t Read(int fd, uint8_t *message, uint32_t length) = 0;
+  // Writes to the serial port.
+  // Args:
+  //  fd: The FD of the port to write to.
+  //  message: The message to write.
+  //  length: The maximum number of bytes to write.
+  // Returns:
+  //  The number of bytes that were actually written, or -1 upon error.
+  virtual int32_t Write(int fd, const uint8_t *message, uint32_t length) = 0;
+};
+
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_LINUX_SERIAL_INTERFACE_H_

--- a/apps/libmc/sim/protobuf/BUILD
+++ b/apps/libmc/sim/protobuf/BUILD
@@ -1,0 +1,9 @@
+proto_library(
+  name = "system_action",
+  srcs = ["system_action.proto"],
+)
+
+cc_proto_library(
+  name = "cc_system_action",
+  deps = [":system_action"],
+)

--- a/apps/libmc/sim/protobuf/BUILD
+++ b/apps/libmc/sim/protobuf/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility=["//apps/libmc/sim:__subpackages__"])
+
 proto_library(
   name = "system_action",
   srcs = ["system_action.proto"],
@@ -6,4 +8,14 @@ proto_library(
 cc_proto_library(
   name = "cc_system_action",
   deps = [":system_action"],
+)
+
+proto_library(
+  name = "test",
+  srcs = ["test.proto"],
+)
+
+cc_proto_library(
+  name = "cc_test",
+  deps = [":test"],
 )

--- a/apps/libmc/sim/protobuf/system_action.proto
+++ b/apps/libmc/sim/protobuf/system_action.proto
@@ -1,6 +1,9 @@
 syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
 
-message Person {
+package libmc.sim;
+
+message SystemAction {
   // If set to true, specifies that we want to shut down the VM.
   bool shut_down = 1;
 }

--- a/apps/libmc/sim/protobuf/system_action.proto
+++ b/apps/libmc/sim/protobuf/system_action.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Person {
+  // If set to true, specifies that we want to shut down the VM.
+  bool shut_down = 1;
+}

--- a/apps/libmc/sim/protobuf/test.proto
+++ b/apps/libmc/sim/protobuf/test.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package libmc.sim.testing;
+
+// A message that is explicitly for testing.
+message TestMessage {
+  int32 field1 = 1;
+  bool field2 = 2;
+}

--- a/apps/libmc/sim/serial_link.cc
+++ b/apps/libmc/sim/serial_link.cc
@@ -1,0 +1,122 @@
+#include "serial_link.h"
+
+#include <fcntl.h>
+#include <string.h>
+#include <sys/types.h>
+#include <termios.h>
+
+#include "linux_serial.h"
+
+namespace libmc {
+namespace sim {
+
+SerialLink::SerialLink() {
+  // Initialize the OS serial layer.
+  os_ = new LinuxSerial;
+}
+
+SerialLink::SerialLink(LinuxSerialInterface *os_serial) : os_(os_serial) {
+  // We don't own this pointer.
+  own_os_ = false;
+}
+
+SerialLink::~SerialLink() {
+  // Close the serial device.
+  if (IsOpen()) {
+    (void)os_->Close(serial_);
+  }
+  if (own_os_) {
+    delete os_;
+  }
+}
+
+bool SerialLink::Open(const char *device, uint32_t baud) {
+  // Open the serial link.
+  serial_ = os_->Open(device);
+  if (serial_ < 0) {
+    // Failure to open device.
+    return false;
+  }
+
+  // Configure the link.
+  if (!ConfigureSerial(baud)) {
+    serial_ = -1;
+    return false;
+  }
+
+  return true;
+}
+
+bool SerialLink::IsOpen() {
+  return serial_ != -1;
+}
+
+bool SerialLink::ConfigureSerial(uint32_t baud) {
+  struct termios tty;
+  memset(&tty, 0, sizeof(tty));
+
+  if (!os_->TcGetAttr(serial_, &tty)) {
+    // Failure to get initial attributes.
+    return false;
+  }
+
+  // Set the baud rate.
+  os_->SetInSpeed(&tty, baud);
+  os_->SetOutSpeed(&tty, baud);
+
+  // Make 8n1.
+  tty.c_cflag &= ~PARENB;
+  tty.c_cflag &= ~CSTOPB;
+  tty.c_cflag &= ~CSIZE;
+  tty.c_cflag |= CS8;
+
+  // No flow control.
+  tty.c_cflag &= ~CRTSCTS;
+
+  // Use raw mode.
+  os_->MakeRaw(&tty);
+
+  // Flush port and apply attributes.
+  os_->TcFlush(serial_, TCIFLUSH);
+  if (!os_->TcSetAttr(serial_, TCSANOW, &tty)) {
+    // Failure to set attributes.
+    return false;
+  }
+
+  return true;
+}
+
+bool SerialLink::SendMessage(const uint8_t *message, uint32_t length) {
+  uint32_t remaining = length;
+  while (remaining > 0) {
+    const int32_t write_ret = os_->Write(serial_, message, remaining);
+    if (write_ret < 0) {
+      // Write failure.
+      return false;
+    }
+
+    remaining -= write_ret;
+    message += write_ret;
+  }
+
+  return true;
+}
+
+bool SerialLink::ReceiveMessage(uint8_t *message, uint32_t length) {
+  uint32_t remaining = length;
+  while (remaining > 0) {
+    const int32_t read_ret = os_->Read(serial_, message, remaining);
+    if (read_ret < 0) {
+      // Read failure.
+      return false;
+    }
+
+    remaining -= read_ret;
+    message += read_ret;
+  }
+
+  return true;
+}
+
+}  // namespace sim
+}  // namespace libmc

--- a/apps/libmc/sim/serial_link.cc
+++ b/apps/libmc/sim/serial_link.cc
@@ -118,5 +118,11 @@ bool SerialLink::ReceiveMessage(uint8_t *message, uint32_t length) {
   return true;
 }
 
+int32_t SerialLink::ReceivePartialMessage(uint8_t *message,
+                                          uint32_t max_length) {
+  // For receiving, we're fine with reading a partial message.
+  return os_->Read(serial_, message, max_length);
+}
+
 }  // namespace sim
 }  // namespace libmc

--- a/apps/libmc/sim/serial_link.h
+++ b/apps/libmc/sim/serial_link.h
@@ -4,12 +4,13 @@
 #include <stdint.h>
 
 #include "linux_serial_interface.h"
+#include "serial_link_interface.h"
 
 namespace libmc {
 namespace sim {
 
 // Manages low-level communication on the serial link with the simulation host.
-class SerialLink {
+class SerialLink : public SerialLinkInterface {
  public:
   // Default constructor should be used normally.
   SerialLink();
@@ -18,32 +19,14 @@ class SerialLink {
   // Args:
   //  os_serial: The OS serial interface layer to use.
   SerialLink(LinuxSerialInterface *os_serial);
-  ~SerialLink();
+  virtual ~SerialLink();
 
-  // Initializes the serial link.
-  // Args:
-  //  device: The serial device to communicate on.
-  //  baud: The baudrate to use for communication.
-  // Returns:
-  //  True if opening the connection succeeded, false otherwise.
-  bool Open(const char *device, uint32_t baud);
-  // Returns true if the link is open, false otherwise.
-  bool IsOpen();
+  virtual bool Open(const char *device, uint32_t baud);
+  virtual bool IsOpen();
 
-  // Send a message on the serial device.
-  // Args:
-  //  message: The message to send.
-  //  length: The length of the message.
-  // Returns:
-  //  True if sending the message was successful, false otherwise.
-  bool SendMessage(const uint8_t *message, uint32_t length);
-  // Receive a message from the serial device.
-  // Args:
-  //  message: Where to write the received message.
-  //  length: The length of the message to receive.
-  // Returns:
-  //  True if the message was successfully received, false otherwise
-  bool ReceiveMessage(uint8_t *message, uint32_t length);
+  virtual bool SendMessage(const uint8_t *message, uint32_t length);
+  virtual bool ReceiveMessage(uint8_t *message, uint32_t length);
+  virtual int32_t ReceivePartialMessage(uint8_t *message, uint32_t length);
 
  private:
   // Configures the internal serial link.

--- a/apps/libmc/sim/serial_link.h
+++ b/apps/libmc/sim/serial_link.h
@@ -1,0 +1,65 @@
+#ifndef LIBMC_SIM_SERIAL_LINK_H_
+#define LIBMC_SIM_SERIAL_LINK_H_
+
+#include <stdint.h>
+
+#include "linux_serial_interface.h"
+
+namespace libmc {
+namespace sim {
+
+// Manages low-level communication on the serial link with the simulation host.
+class SerialLink {
+ public:
+  // Default constructor should be used normally.
+  SerialLink();
+  // Alternate constructor that allows us to do dependency injection during
+  // testing.
+  // Args:
+  //  os_serial: The OS serial interface layer to use.
+  SerialLink(LinuxSerialInterface *os_serial);
+  ~SerialLink();
+
+  // Initializes the serial link.
+  // Args:
+  //  device: The serial device to communicate on.
+  //  baud: The baudrate to use for communication.
+  // Returns:
+  //  True if opening the connection succeeded, false otherwise.
+  bool Open(const char *device, uint32_t baud);
+  // Returns true if the link is open, false otherwise.
+  bool IsOpen();
+
+  // Send a message on the serial device.
+  // Args:
+  //  message: The message to send.
+  //  length: The length of the message.
+  // Returns:
+  //  True if sending the message was successful, false otherwise.
+  bool SendMessage(const uint8_t *message, uint32_t length);
+  // Receive a message from the serial device.
+  // Args:
+  //  message: Where to write the received message.
+  //  length: The length of the message to receive.
+  // Returns:
+  //  True if the message was successfully received, false otherwise
+  bool ReceiveMessage(uint8_t *message, uint32_t length);
+
+ private:
+  // Configures the internal serial link.
+  // Args:
+  //  The baud rate to use.
+  bool ConfigureSerial(uint32_t baud);
+
+  // The FD of the serial device.
+  int serial_ = -1;
+  // Handle for the OS serial interface.
+  LinuxSerialInterface *os_;
+  // Keeps track of whether we own the handle.
+  bool own_os_ = true;
+};
+
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_SERIAL_LINK_H_

--- a/apps/libmc/sim/serial_link_interface.h
+++ b/apps/libmc/sim/serial_link_interface.h
@@ -1,0 +1,51 @@
+#ifndef LIBMC_SIM_SERIAL_LINK_INTERFACE_H_
+#define LIBMC_SIM_SERIAL_LINK_INTERFACE_H_
+
+#include <stdint.h>
+
+namespace libmc {
+namespace sim {
+
+// Defines abstract interface for the SerialLink class.
+class SerialLinkInterface {
+ public:
+  virtual ~SerialLinkInterface() = default;
+
+  // Initializes the serial link.
+  // Args:
+  //  device: The serial device to communicate on.
+  //  baud: The baudrate to use for communication.
+  // Returns:
+  //  True if opening the connection succeeded, false otherwise.
+  virtual bool Open(const char *device, uint32_t baud) = 0;
+  // Returns true if the link is open, false otherwise.
+  virtual bool IsOpen() = 0;
+
+  // Send a message on the serial device.
+  // Args:
+  //  message: The message to send.
+  //  length: The length of the message.
+  // Returns:
+  //  True if sending the message was successful, false otherwise.
+  virtual bool SendMessage(const uint8_t *message, uint32_t length) = 0;
+  // Receive a message from the serial device.
+  // Args:
+  //  message: Where to write the received message.
+  //  length: The length of the message to receive.
+  // Returns:
+  //  True if it successfully received the message, false otherwise.
+  virtual bool ReceiveMessage(uint8_t *message, uint32_t length) = 0;
+  // Receive a message from the serial device. It might not read the entire
+  // length.
+  // Args:
+  //  message: Where to write the received message.
+  //  length: The length of the message to receive.
+  // Returns:
+  //  The number of bytes total that it received.
+  virtual int32_t ReceivePartialMessage(uint8_t *message, uint32_t length) = 0;
+};
+
+}  // namespace libmc
+}  // namespace sim
+
+#endif  // LIBMC_SIM_SERIAL_LINK_INTERFACE_H_

--- a/apps/libmc/sim/simulator_com.cc
+++ b/apps/libmc/sim/simulator_com.cc
@@ -1,0 +1,182 @@
+#include "simulator_com.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include "apps/libmc/constants.h"
+#include "cows.h"
+#include "serial_link.h"
+
+namespace libmc {
+namespace sim {
+
+SimulatorCom::SimulatorCom() : SimulatorCom(new SerialLink, new Cows) {
+  // Indicate that we own this serial link and cows implementation.
+  own_serial_ = true;
+  own_cows_ = true;
+}
+
+SimulatorCom::SimulatorCom(SerialLinkInterface *serial_link,
+                           CowsInterface *cows)
+    : serial_(serial_link), cows_(cows) {
+  // Allocate the buffer memory.
+  send_buffer_ = new uint8_t[constants::kSimulator.MaxPacketSize];
+  receive_buffer_ = new uint8_t[constants::kSimulator.MaxPacketSize];
+}
+
+SimulatorCom::~SimulatorCom() {
+  // Free the serial link and Cows if we own them.
+  if (own_serial_) {
+    delete serial_;
+  }
+  if (own_cows_) {
+    delete cows_;
+  }
+
+  // Free the buffer memory.
+  delete[] send_buffer_;
+  delete[] receive_buffer_;
+}
+
+bool SimulatorCom::Open() {
+  // Open the underlying serial connections.
+  const char *device = constants::kSimulator.Device;
+  const uint32_t baud = constants::kSimulator.BaudRate;
+
+  if (!serial_->Open(device, baud)) {
+    return false;
+  }
+
+  // Send the first zero separator so the recipient knows a message is coming.
+  const uint8_t zero[] = {0, 0};
+  return serial_->SendMessage(zero, 2);
+}
+
+bool SimulatorCom::SendMessage(const ProtoMessage &message) {
+  const uint32_t length = message.ByteSizeLong();
+  // COWS adds 4 bytes of overhead.
+  const uint32_t cows_length = length + 4;
+  // We need the length to be a multiple of words, because that's how we stuff
+  // it.
+  const uint32_t padded_length = cows_length + cows_length % 2;
+
+  // Check that the message fits in the buffer.
+  assert(padded_length < constants::kSimulator.MaxPacketSize);
+
+  // Serialize the message.
+  if (!message.SerializeToArray(send_buffer_ + 2, length)) {
+    return false;
+  }
+
+  // Stuff the message. (This uses the first word for the overhead.)
+  cows_->CowsStuff(reinterpret_cast<uint16_t *>(send_buffer_),
+                   padded_length / 2);
+
+  // Add the zero separator at the end. (We don't need the padding)
+  send_buffer_[cows_length - 2] = 0;
+  send_buffer_[cows_length - 1] = 0;
+
+  // Send the message on the wire.
+  return serial_->SendMessage(send_buffer_, cows_length);
+}
+
+bool SimulatorCom::ReceiveMessage(ProtoMessage *message) {
+  if (!packet_synced_) {
+    // First, sync to the start of the packet.
+    if (!SyncToPacket()) {
+      return false;
+    }
+    packet_synced_ = true;
+  }
+
+  // Now, receive the rest of the packet into the buffer.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  uint32_t search_start = 0;
+  while (!FindPacketEnd(search_start)) {
+    if (receive_space_used_ == max_length) {
+      // We've filled up our entire buffer and still don't have a packet.
+      // Something is wrong.
+      receive_space_used_ = 0;
+      packet_synced_ = false;
+      return false;
+    }
+
+    const int32_t bytes_read =
+        serial_->ReceivePartialMessage(receive_buffer_ + receive_space_used_,
+                                       max_length - receive_space_used_);
+    // If this is true, it's probably a serial misconfiguration.
+    assert(bytes_read != 0);
+    if (bytes_read < 0) {
+      // Reading failure.
+      receive_space_used_ = 0;
+      packet_synced_ = false;
+      return false;
+    }
+
+    // Since the separator is two bytes instead of one, we actually have to
+    // overlap slightly with the previous search area when looking for it.
+    search_start = receive_space_used_ - 1;
+    receive_space_used_ += bytes_read;
+  }
+
+  // Parse the message.
+  const uint32_t packet_end = FindPacketEnd(search_start);
+  // The packet might not end on an even byte, but we need to make sure COWS
+  // unstuffs the entire thing.
+  const uint32_t cows_end = (packet_end + packet_end % 2) / 2;
+  cows_->CowsUnstuff(reinterpret_cast<uint16_t *>(receive_buffer_), cows_end);
+  // Don't parse the overhead word.
+  const bool parsed =
+      message->ParseFromArray(receive_buffer_ + 2, packet_end - 2);
+
+  // Delete the message from the buffer.
+  ClearPacket(packet_end);
+
+  return parsed;
+}
+
+bool SimulatorCom::SyncToPacket() {
+  uint8_t separator[2];
+
+  // Read words until we find the separator.
+  while (true) {
+    if (!serial_->ReceiveMessage(separator, 2)) {
+      // Reading failure.
+      return false;
+    }
+
+    // Compare the separator.
+    const uint8_t expected[] = {0, 0};
+    if (memcmp(expected, separator, 2) == 0) {
+      // We found the packet start.
+      return true;
+    }
+  }
+}
+
+uint32_t SimulatorCom::FindPacketEnd(uint32_t start) {
+  // Find the zero separator.
+  for (uint32_t i = start + 1; i < receive_space_used_; ++i) {
+    if (receive_buffer_[i - 1] == 0 && receive_buffer_[i] == 0) {
+      // We found the separator, which marks the end of the packet.
+      return i - 1;
+    }
+  }
+
+  // We didn't find the end.
+  return 0;
+}
+
+void SimulatorCom::ClearPacket(uint32_t packet_end) {
+  assert(receive_space_used_ - packet_end >= 2);
+
+  // Shift everything down, omitting the separator.
+  memmove(receive_buffer_, receive_buffer_ + packet_end + 2,
+          receive_space_used_ - packet_end - 2);
+
+  // We are now clear to write after the end of whatever data is remaining.
+  receive_space_used_ -= packet_end + 2;
+}
+
+}  // namespace sim
+}  // namespace libmc

--- a/apps/libmc/sim/simulator_com.h
+++ b/apps/libmc/sim/simulator_com.h
@@ -1,0 +1,85 @@
+#ifndef LIBMC_SIM_SIMULATOR_COM_H_
+#define LIBMC_SIM_SIMULATOR_COM_H_
+
+#include "google/protobuf/message_lite.h"
+
+#include "cows_interface.h"
+#include "serial_link_interface.h"
+
+namespace libmc {
+namespace sim {
+
+typedef ::google::protobuf::MessageLite ProtoMessage;
+
+// Defines a high-level interface for communicating with the simulation.
+class SimulatorCom {
+ public:
+  SimulatorCom();
+  // Allows us to inject the SerialLink and Cows to use when unit testing.
+  // Args:
+  //  serial_link: The serial link object to use.
+  //  cows: The Cows object to use.
+  SimulatorCom(SerialLinkInterface *serial_link, CowsInterface *cows);
+  ~SimulatorCom();
+
+  // Opens a new connection on the simulator serial port.
+  // Returns:
+  //  True if it succeeded in opening the connection, false otherwise.
+  bool Open();
+
+  // Sends a message to the simulator.
+  // Args:
+  //  message: The message to send.
+  // Returns:
+  //  True if sending the message succeeded, false otherwise.
+  bool SendMessage(const ProtoMessage &message);
+  // Receives a message from the simulator.
+  // Args:
+  //  message: The message to receive into.
+  // Returns:
+  //  True if receiving the message succeeded, false otherwise.
+  bool ReceiveMessage(ProtoMessage *message);
+
+ private:
+  // Reads from the serial port until it finds a valid packet separator.
+  // Returns:
+  //  True if it successfully found the separator, false if a read error
+  //  occurred.
+  bool SyncToPacket();
+  // Finds the end of the first packet in the buffer.
+  // Args:
+  //  start: Where to start searching in the buffer.
+  // Returns:
+  //  The index of byte after the end of the packet, or 0 if there is no
+  //  complete packet.
+  uint32_t FindPacketEnd(uint32_t start);
+  // Removes the first packet in the buffer, and shifts everything after it
+  // down.
+  // Args:
+  //  packet_end: The index of the byte after the end of the first packet.
+  void ClearPacket(uint32_t packet_end);
+
+  // Internal buffer that we use for storing serialized messages to be sent.
+  uint8_t *send_buffer_;
+  // Internal buffer that we use for storing received messages.
+  uint8_t *receive_buffer_;
+  // Whether we're synced to packets.
+  bool packet_synced_ = false;
+  // Amount of space used in the receive buffer.
+  uint32_t receive_space_used_ = 0;
+
+  // Internal low-level serial interface.
+  SerialLinkInterface *serial_;
+  // Whether we have ownership of the serial link.
+  bool own_serial_ = false;
+
+  // Internal COWS implementation.
+  CowsInterface *cows_;
+  // Whether we have ownership of cows.
+  bool own_cows_ = false;
+};
+
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_SIMULATOR_COM_H_

--- a/apps/libmc/sim/tests/BUILD
+++ b/apps/libmc/sim/tests/BUILD
@@ -1,0 +1,43 @@
+cc_library(
+  name = "mocks",
+  copts = ["-Iexternal/gtest/googlemock/include"],
+  hdrs = glob(["mock_*.h"]),
+  deps = ["//apps/libmc/sim",
+          "@gtest//:gmock"],
+  restricted_to = ["//cpus:x86"],
+)
+
+cc_test(
+  name = "cows_test",
+  copts = ["-Iexternal/gtest/googletest/include"],
+  srcs = ["cows_test.cc"],
+  deps = ["//apps/libmc/sim",
+          "@gtest//:gtest"],
+  size = "small",
+  restricted_to = ["//cpus:x86"],
+)
+
+cc_test(
+  name = "serial_link_pty_test",
+  copts = ["-Iexternal/gtest/googletest/include"],
+  srcs = ["serial_link_pty_test.cc"],
+  deps = ["//apps/libmc/sim",
+          "@gtest//:gtest"],
+  size = "small",
+  restricted_to = ["//cpus:x86"],
+  # Disable sandboxing so we can access the Linux PTY subsystem.
+  tags = ["local"],
+)
+
+cc_test(
+  name = "serial_link_test",
+  copts = ["-Iexternal/gtest/googletest/include",
+           "-Iexternal/gtest/googlemock/include"],
+  srcs = ["serial_link_test.cc"],
+  deps = [":mocks",
+          "//apps/libmc/sim",
+          "@gtest//:gtest",
+          "@gtest//:gmock"],
+  size = "small",
+  restricted_to = ["//cpus:x86"],
+)

--- a/apps/libmc/sim/tests/BUILD
+++ b/apps/libmc/sim/tests/BUILD
@@ -41,3 +41,17 @@ cc_test(
   size = "small",
   restricted_to = ["//cpus:x86"],
 )
+
+cc_test(
+  name = "simulator_com_test",
+  copts = ["-Iexternal/gtest/googletest/include",
+           "-Iexternal/gtest/googlemock/include"],
+  srcs = ["simulator_com_test.cc"],
+  deps = [":mocks",
+          "//apps/libmc/sim",
+          "//apps/libmc/sim/protobuf:cc_test",
+          "@gtest//:gtest",
+          "@gtest//:gmock"],
+  size = "small",
+  restricted_to = ["//cpus:x86"],
+)

--- a/apps/libmc/sim/tests/cows_test.cc
+++ b/apps/libmc/sim/tests/cows_test.cc
@@ -61,6 +61,9 @@ class CowsTest : public ::testing::Test {
 
   // Large buffer for testing purposes.
   uint16_t *test_buffer_;
+
+  // Cows implementation for testing.
+  Cows cows_;
 };
 
 // Make sure we can stuff and unstuff something.
@@ -70,15 +73,13 @@ TEST_F(CowsTest, StuffUnstuffTest) {
   memcpy(test_buffer_copy, test_buffer_, sizeof(uint16_t) * kBufferSize);
 
   // Stuff it.
-  CowsStuff(test_buffer_, kBufferSize);
+  cows_.CowsStuff(test_buffer_, kBufferSize);
 
-  // The packet separator should have been added.
-  EXPECT_EQ(0, test_buffer_[0]);
   // Check that we don't have extraneous zeros.
   CheckInternalSeparators(test_buffer_, kBufferSize);
 
   // Unstuff it.
-  CowsUnstuff(test_buffer_, kBufferSize);
+  cows_.CowsUnstuff(test_buffer_, kBufferSize);
 
   // Check that it's the same.
   ComparePackets(test_buffer_, test_buffer_copy, kBufferSize);
@@ -89,7 +90,7 @@ TEST_F(CowsTest, StuffUnstuffTest) {
 // Make sure we can stuff and unstuff a packet with no zeros.
 TEST_F(CowsTest, NoZerosTest) {
   // Stuff the packet, which by definition removes the zeros.
-  CowsStuff(test_buffer_, kBufferSize);
+  cows_.CowsStuff(test_buffer_, kBufferSize);
   CheckInternalSeparators(test_buffer_, kBufferSize);
 
   // Copy the testing buffer so we have something to compare with.
@@ -97,14 +98,14 @@ TEST_F(CowsTest, NoZerosTest) {
   memcpy(test_buffer_copy, test_buffer_, sizeof(uint16_t) * kBufferSize);
 
   // Stuff it again.
-  CowsStuff(test_buffer_, kBufferSize);
+  cows_.CowsStuff(test_buffer_, kBufferSize);
   CheckInternalSeparators(test_buffer_, kBufferSize);
 
   // Make sure that the next zero word points to the start of the next packet.
-  EXPECT_EQ(kBufferSize - 1, test_buffer_[1]);
+  EXPECT_EQ(kBufferSize - 1, test_buffer_[0]);
 
   // Unstuff it.
-  CowsUnstuff(test_buffer_, kBufferSize);
+  cows_.CowsUnstuff(test_buffer_, kBufferSize);
   // Check that it's the same.
   ComparePackets(test_buffer_, test_buffer_copy, kBufferSize);
 
@@ -121,11 +122,11 @@ TEST_F(CowsTest, ZeroPacketTest) {
   memcpy(test_buffer_copy, test_buffer_, sizeof(uint16_t) * kBufferSize);
 
   // Stuff it.
-  CowsStuff(test_buffer_, kBufferSize);
+  cows_.CowsStuff(test_buffer_, kBufferSize);
   CheckInternalSeparators(test_buffer_, kBufferSize);
 
   // Unstuff it.
-  CowsUnstuff(test_buffer_, kBufferSize);
+  cows_.CowsUnstuff(test_buffer_, kBufferSize);
   // Check that it's the same.
   ComparePackets(test_buffer_, test_buffer_copy, kBufferSize);
 

--- a/apps/libmc/sim/tests/cows_test.cc
+++ b/apps/libmc/sim/tests/cows_test.cc
@@ -1,0 +1,137 @@
+#include <stdint.h>
+#include <string.h>
+
+#include "gtest/gtest.h"
+
+#include "apps/libmc/sim/cows.h"
+
+namespace libmc {
+namespace sim {
+namespace testing {
+namespace {
+
+// The size of the buffer to test with.
+constexpr int kBufferSize = 1024;
+
+// Checks that we don't have any extraneous packet separators within the packet.
+// Args:
+//  packet: The packet to check.
+//  length: The length of the packet.
+void CheckInternalSeparators(const uint16_t *packet, int length) {
+  for (int i = 1; i < length; ++i) {
+    ASSERT_NE(0, packet[i]);
+  }
+}
+
+// Compares two packets and makes sure they're identical.
+// Args:
+//  packet1: The first packet.
+//  packet2: The second packet.
+//  length: The size of the packets.
+void ComparePackets(const uint16_t *packet1, const uint16_t *packet2,
+                    int length) {
+  // The first two words are reserved by the COWS algorithm.
+  for (int i = 2; i < length; ++i) {
+    EXPECT_EQ(packet2[i], packet1[i]);
+  }
+}
+
+}  // namespace
+
+class CowsTest : public ::testing::Test {
+ protected:
+  CowsTest() : test_buffer_(new uint16_t[kBufferSize]) {}
+  ~CowsTest() {
+    delete[] test_buffer_;
+  }
+
+  virtual void SetUp() {
+    // Fill it with a pattern.
+    test_buffer_[2] = 0;
+    uint16_t base = 3;
+    for (int i = 3; i < kBufferSize; ++i) {
+      if (!test_buffer_[i - 1]) {
+        test_buffer_[i] = base;
+        base *= 5;
+      } else {
+        test_buffer_[i] = test_buffer_[i - 1] << 1;
+      }
+    }
+  }
+
+  // Large buffer for testing purposes.
+  uint16_t *test_buffer_;
+};
+
+// Make sure we can stuff and unstuff something.
+TEST_F(CowsTest, StuffUnstuffTest) {
+  // Copy the testing buffer so we have something to compare with.
+  uint16_t *test_buffer_copy = new uint16_t[kBufferSize];
+  memcpy(test_buffer_copy, test_buffer_, sizeof(uint16_t) * kBufferSize);
+
+  // Stuff it.
+  CowsStuff(test_buffer_, kBufferSize);
+
+  // The packet separator should have been added.
+  EXPECT_EQ(0, test_buffer_[0]);
+  // Check that we don't have extraneous zeros.
+  CheckInternalSeparators(test_buffer_, kBufferSize);
+
+  // Unstuff it.
+  CowsUnstuff(test_buffer_, kBufferSize);
+
+  // Check that it's the same.
+  ComparePackets(test_buffer_, test_buffer_copy, kBufferSize);
+
+  delete[] test_buffer_copy;
+}
+
+// Make sure we can stuff and unstuff a packet with no zeros.
+TEST_F(CowsTest, NoZerosTest) {
+  // Stuff the packet, which by definition removes the zeros.
+  CowsStuff(test_buffer_, kBufferSize);
+  CheckInternalSeparators(test_buffer_, kBufferSize);
+
+  // Copy the testing buffer so we have something to compare with.
+  uint16_t *test_buffer_copy = new uint16_t[kBufferSize];
+  memcpy(test_buffer_copy, test_buffer_, sizeof(uint16_t) * kBufferSize);
+
+  // Stuff it again.
+  CowsStuff(test_buffer_, kBufferSize);
+  CheckInternalSeparators(test_buffer_, kBufferSize);
+
+  // Make sure that the next zero word points to the start of the next packet.
+  EXPECT_EQ(kBufferSize - 1, test_buffer_[1]);
+
+  // Unstuff it.
+  CowsUnstuff(test_buffer_, kBufferSize);
+  // Check that it's the same.
+  ComparePackets(test_buffer_, test_buffer_copy, kBufferSize);
+
+  delete[] test_buffer_copy;
+}
+
+// Make sure we can stuff a packet that's all zeros.
+TEST_F(CowsTest, ZeroPacketTest) {
+  // Fill a packet with zeros.
+  memset(test_buffer_, 0, sizeof(uint16_t) * kBufferSize);
+
+  // Copy the testing buffer so we have something to compare with.
+  uint16_t *test_buffer_copy = new uint16_t[kBufferSize];
+  memcpy(test_buffer_copy, test_buffer_, sizeof(uint16_t) * kBufferSize);
+
+  // Stuff it.
+  CowsStuff(test_buffer_, kBufferSize);
+  CheckInternalSeparators(test_buffer_, kBufferSize);
+
+  // Unstuff it.
+  CowsUnstuff(test_buffer_, kBufferSize);
+  // Check that it's the same.
+  ComparePackets(test_buffer_, test_buffer_copy, kBufferSize);
+
+  delete[] test_buffer_copy;
+}
+
+}  // namespace testing
+}  // namespace sim
+}  // namespace libmc

--- a/apps/libmc/sim/tests/mock_cows.h
+++ b/apps/libmc/sim/tests/mock_cows.h
@@ -1,0 +1,25 @@
+#ifndef LIBMC_SIM_TESTS_MOCK_COWS_H_
+#define LIBMC_SIM_TESTS_MOCK_COWS_H_
+
+#include <stdint.h>
+
+#include "gmock/gmock.h"
+
+#include "apps/libmc/sim/cows_interface.h"
+
+namespace libmc {
+namespace sim {
+namespace testing {
+
+// Mock class for Cows.
+class MockCows : public CowsInterface {
+ public:
+  MOCK_METHOD2(CowsStuff, void(uint16_t *buffer, uint16_t length));
+  MOCK_METHOD2(CowsUnstuff, void(uint16_t *buffer, uint16_t length));
+};
+
+}  // namespace testing
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_TESTS_MOCK_COWS_H_

--- a/apps/libmc/sim/tests/mock_linux_serial.h
+++ b/apps/libmc/sim/tests/mock_linux_serial.h
@@ -1,0 +1,37 @@
+#ifndef LIBMC_SIM_TESTS_MOCK_LINUX_SERIAL_H_
+#define LIBMC_SIM_TESTS_MOCK_LINUX_SERIAL_H_
+
+#include <stdint.h>
+#include <termios.h>
+
+#include "gmock/gmock.h"
+
+#include "apps/libmc/sim/linux_serial_interface.h"
+
+namespace libmc {
+namespace sim {
+namespace testing {
+
+// Mock class for LinuxSerial.
+class MockLinuxSerial : public LinuxSerialInterface {
+ public:
+  MOCK_METHOD1(Open, int(const char *device));
+  MOCK_METHOD1(Close, bool(int fd));
+
+  MOCK_METHOD2(TcGetAttr, bool(int fd, termios *attrs));
+  MOCK_METHOD3(TcSetAttr, bool(int fd, int action, const termios *attrs));
+  MOCK_METHOD2(SetOutSpeed, void(termios *serial, uint32_t baud));
+  MOCK_METHOD2(SetInSpeed, void(termios *serial, uint32_t baud));
+
+  MOCK_METHOD1(MakeRaw, void(termios *serial));
+
+  MOCK_METHOD2(TcFlush, void(int fd, int options));
+  MOCK_METHOD3(Read, int32_t(int fd, uint8_t *message, uint32_t length));
+  MOCK_METHOD3(Write, int32_t(int fd, const uint8_t *message, uint32_t length));
+};
+
+}  // namespace testing
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_TESTS_MOCK_LINUX_SERIAL_H_

--- a/apps/libmc/sim/tests/mock_serial_link.h
+++ b/apps/libmc/sim/tests/mock_serial_link.h
@@ -1,0 +1,30 @@
+#ifndef LIBMC_SIM_TESTS_MOCK_SERIAL_LINK_H_
+#define LIBMC_SIM_TESTS_MOCK_SERIAL_LINK_H_
+
+#include <stdint.h>
+
+#include "gmock/gmock.h"
+
+#include "apps/libmc/sim/serial_link_interface.h"
+
+namespace libmc {
+namespace sim {
+namespace testing {
+
+// Mock class for SerialLink.
+class MockSerialLink : public SerialLinkInterface {
+ public:
+  MOCK_METHOD2(Open, bool(const char *device, uint32_t baud));
+  MOCK_METHOD0(IsOpen, bool());
+
+  MOCK_METHOD2(SendMessage, bool(const uint8_t *message, uint32_t length));
+  MOCK_METHOD2(ReceiveMessage, bool(uint8_t *message, uint32_t length));
+  MOCK_METHOD2(ReceivePartialMessage,
+               int32_t(uint8_t *message, uint32_t length));
+};
+
+}  // namespace testing
+}  // namespace sim
+}  // namespace libmc
+
+#endif  // LIBMC_SIM_TESTS_MOCK_SERIAL_LINK_H_

--- a/apps/libmc/sim/tests/serial_link_pty_test.cc
+++ b/apps/libmc/sim/tests/serial_link_pty_test.cc
@@ -1,0 +1,165 @@
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+
+#include "apps/libmc/sim/serial_link.h"
+
+// Needed for grantpt() and unlockpt().
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE
+#endif  // _XOPEN_SOURCE
+
+namespace libmc {
+namespace sim {
+namespace testing {
+
+// Tests for the serial link class that use the PTY interface. They don't test
+// many corner cases, but instead ensure that the code works in the "real
+// world."
+class SerialLinkPtyTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    // Create a new PTY device.
+    ASSERT_TRUE(CreatePty());
+    // Open the serial link.
+    ASSERT_TRUE(link_.Open(pty_name_, 115200));
+  }
+
+  virtual void TearDown() {
+    // Destroy the PTY device.
+    ClosePty();
+  }
+
+  // Receives a message that was sent on the PTY, and checks that it matches
+  // some expected value.
+  // Args:
+  //  expected: The message we expect.
+  // Returns:
+  //  True if the received message matched the expected message, false
+  //  otherwise, or if there was a failure.
+  bool ReceiveAndCheckMessage(const char *expected) {
+    // Account for the null.
+    const uint32_t length = strlen(expected) + 1;
+
+    // Read the message.
+    char *actual = new char[length];
+    uint32_t actual_read = 0;
+    while (actual_read < length) {
+      const int32_t read_cycle =
+          read(pty_master_, actual + actual_read, length - actual_read);
+      if (read_cycle < 0) {
+        return false;
+      }
+      actual_read += read_cycle;
+    }
+
+    // Compare the results.
+    const bool equal = memcmp(expected, actual, length) == 0;
+
+    delete[] actual;
+
+    return equal;
+  }
+
+  // Writes a message to the PTY such that it can be received later.
+  // Args:
+  //  message: The message to write.
+  // Returns:
+  //  True upon success, false on failure.
+  bool WriteMessage(const char *message) {
+    // Account for the null.
+    const uint32_t length = strlen(message) + 1;
+
+    uint32_t wrote_bytes = 0;
+    while (wrote_bytes < strlen(message) + 1) {
+      const int32_t write_cycle =
+          write(pty_master_, message + wrote_bytes, length - wrote_bytes);
+      if (write_cycle < 0) {
+        // Unexpected failure.
+        return false;
+      }
+      wrote_bytes += write_cycle;
+    }
+
+    return true;
+  }
+
+  // Name of the PTY slave device.
+  char *pty_name_;
+  // The FD of the PTY master.
+  int pty_master_;
+
+  // The serial link we are testing with.
+  SerialLink link_;
+
+ private:
+  // Creates and sets the PTY pair to use for this suite.
+  // Returns:
+  //  True if it successfully created the PTY, false otherwise.
+  bool CreatePty() {
+    pty_master_ = open("/dev/ptmx", O_RDWR);
+    if (pty_master_ < 0) {
+      // Failure to open the PTMX for some reason.
+      perror("open: ");
+      return false;
+    }
+
+    if (grantpt(pty_master_)) {
+      perror("grantpt: ");
+      return false;
+    }
+    if (unlockpt(pty_master_)) {
+      perror("unlockpt: ");
+      return false;
+    }
+
+    pty_name_ = ptsname(pty_master_);
+    return true;
+  }
+
+  // Closes the PTY.
+  void ClosePty() {
+    close(pty_master_);
+  }
+};
+
+// Tests that we can send a message through the serial link under normal
+// conditions.
+TEST_F(SerialLinkPtyTest, MessageSendTest) {
+  // Try sending some stuff over the link.
+  const char *message = "I am a very serious message. Farts.";
+  EXPECT_TRUE(link_.SendMessage(reinterpret_cast<const uint8_t *>(message),
+                                strlen(message) + 1));
+
+  // Now, receive and compare.
+  EXPECT_TRUE(ReceiveAndCheckMessage(message));
+}
+
+// Tests that we can receive a message from the serial link under normal
+// conditions.
+TEST_F(SerialLinkPtyTest, MessageReceiveTest) {
+  // Add some stuff to receive.
+  const char *message = "Shirley is a lizard person.";
+  ASSERT_TRUE(WriteMessage(message));
+
+  // Try receiving it.
+  const uint32_t length = strlen(message) + 1;
+  uint8_t *received = new uint8_t[length];
+  EXPECT_TRUE(link_.ReceiveMessage(received, length));
+
+  // Compare the messages.
+  EXPECT_EQ(0, memcmp(message, received, length));
+
+  delete[] received;
+}
+
+}  // namespace testing
+}  // namespace sim
+}  // namespace libmc

--- a/apps/libmc/sim/tests/serial_link_pty_test.cc
+++ b/apps/libmc/sim/tests/serial_link_pty_test.cc
@@ -150,7 +150,7 @@ TEST_F(SerialLinkPtyTest, MessageReceiveTest) {
   ASSERT_TRUE(WriteMessage(message));
 
   // Try receiving it.
-  const uint32_t length = strlen(message) + 1;
+  const int32_t length = strlen(message) + 1;
   uint8_t *received = new uint8_t[length];
   EXPECT_TRUE(link_.ReceiveMessage(received, length));
 
@@ -159,6 +159,25 @@ TEST_F(SerialLinkPtyTest, MessageReceiveTest) {
 
   delete[] received;
 }
+
+// Same as the above, but tests with a partial message.
+TEST_F(SerialLinkPtyTest, PartialMessageReceiveTest) {
+  // Add some stuff to receive.
+  const char *message = "Shirley is a lizard person.";
+  ASSERT_TRUE(WriteMessage(message));
+
+  // Try receiving it.
+  const int32_t length = strlen(message) + 1;
+  uint8_t *received = new uint8_t[length + 1];
+  // Try to receive something longer. It should only receive what it has.
+  EXPECT_EQ(length, link_.ReceivePartialMessage(received, length + 1));
+
+  // Compare the messages.
+  EXPECT_EQ(0, memcmp(message, received, length));
+
+  delete[] received;
+}
+
 
 }  // namespace testing
 }  // namespace sim

--- a/apps/libmc/sim/tests/serial_link_test.cc
+++ b/apps/libmc/sim/tests/serial_link_test.cc
@@ -1,0 +1,248 @@
+#include <stdint.h>
+#include <string.h>
+#include <termios.h>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "apps/libmc/sim/linux_serial_interface.h"
+#include "apps/libmc/sim/serial_link.h"
+#include "mock_linux_serial.h"
+
+namespace libmc {
+namespace sim {
+namespace testing {
+namespace {
+
+// Constants to use for opening new devices.
+const char *kDevice = "/dev/my_happy_device";
+const int kFd = 4;
+const uint32_t kBaud = 115200;
+
+}  // namespace
+
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArrayArgument;
+using ::testing::_;
+
+// Tests for the serial link class.
+class SerialLinkTest : public ::testing::Test {
+ protected:
+  // Inject the serial layer mock.
+  SerialLinkTest() : serial_(&mock_serial_) {}
+
+  virtual void TearDown() {
+    // Expect it to try to close the device.
+    if (serial_.IsOpen()) {
+      EXPECT_CALL(mock_serial_, Close(kFd)).Times(1).WillOnce(Return(true));
+    }
+  }
+
+  // Helper function for opening the serial port and performing associated
+  // tests.
+  void OpenSerial() {
+    // Set up the mock to look like opening succeeded.
+    EXPECT_CALL(mock_serial_, Open(kDevice)).Times(1).WillOnce(Return(kFd));
+    // Set up the mock to look like configuration also succeeded.
+    EXPECT_CALL(mock_serial_, TcGetAttr(kFd, _)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(mock_serial_, SetInSpeed(_, kBaud)).Times(1);
+    EXPECT_CALL(mock_serial_, SetOutSpeed(_, kBaud)).Times(1);
+    EXPECT_CALL(mock_serial_, MakeRaw(_)).Times(1);
+    EXPECT_CALL(mock_serial_, TcFlush(kFd, _)).Times(1);
+    EXPECT_CALL(mock_serial_, TcSetAttr(kFd, _, _))
+        .Times(1)
+        .WillOnce(Return(true));
+
+    // Perform the call to open, which should work.
+    EXPECT_TRUE(serial_.Open(kDevice, kBaud));
+    EXPECT_TRUE(serial_.IsOpen());
+  }
+
+  // Serial link mocks.
+  MockLinuxSerial mock_serial_;
+
+  // Serial link class to use for testing.
+  SerialLink serial_;
+};
+
+// Tests that Open works under normal conditions.
+TEST_F(SerialLinkTest, OpenTest) {
+  OpenSerial();
+}
+
+// Tests that Open handles a failure to open the device.
+TEST_F(SerialLinkTest, OpenDeviceOpenFailureTest) {
+  // Set up the mock to look like opening failed.
+  EXPECT_CALL(mock_serial_, Open(kDevice)).Times(1).WillOnce(Return(-1));
+
+  // Perform the call to open, which should fail.
+  EXPECT_FALSE(serial_.Open(kDevice, kBaud));
+  EXPECT_FALSE(serial_.IsOpen());
+}
+
+// Tests Open handles a failure to configure the device.
+TEST_F(SerialLinkTest, OpenDeviceConfigFailureTest) {
+  // Set up the mock to look like opening succeeded.
+  EXPECT_CALL(mock_serial_, Open(kDevice)).Times(2).WillRepeatedly(Return(kFd));
+  // Set up the mock function to look like getting attributes failed.
+  EXPECT_CALL(mock_serial_, TcGetAttr(kFd, _))
+      .Times(2)
+      .WillOnce(Return(false))
+      .WillOnce(Return(true));
+
+  // Perform the call to open, which should fail.
+  EXPECT_FALSE(serial_.Open(kDevice, kBaud));
+  EXPECT_FALSE(serial_.IsOpen());
+
+  // The other way this could fail is if setting attributes fails.
+  EXPECT_CALL(mock_serial_, TcSetAttr(kFd, _, _))
+      .Times(1)
+      .WillOnce(Return(false));
+  // Everything else should work, though.
+  EXPECT_CALL(mock_serial_, SetInSpeed(_, kBaud)).Times(1);
+  EXPECT_CALL(mock_serial_, SetOutSpeed(_, kBaud)).Times(1);
+  EXPECT_CALL(mock_serial_, MakeRaw(_)).Times(1);
+  EXPECT_CALL(mock_serial_, TcFlush(kFd, _)).Times(1);
+
+  // Perform the call to open, which should fail.
+  EXPECT_FALSE(serial_.Open(kDevice, kBaud));
+  EXPECT_FALSE(serial_.IsOpen());
+}
+
+// Tests that SendMessage works under normal conditions.
+TEST_F(SerialLinkTest, SendMessageTest) {
+  OpenSerial();
+
+  // Message to test with.
+  const char *message = "poptart";
+  const uint8_t *byte_message = reinterpret_cast<const uint8_t *>(message);
+  const uint32_t length = strlen(message) + 1;
+
+  // Make it look like writing succeeded on the first try.
+  EXPECT_CALL(mock_serial_, Write(kFd, byte_message, length))
+      .Times(1)
+      .WillOnce(Return(length));
+
+  EXPECT_TRUE(serial_.SendMessage(byte_message, length));
+}
+
+// Tests that SendMessage works when it has to split the message up into parts.
+TEST_F(SerialLinkTest, SendMessageSplitTest) {
+  OpenSerial();
+
+  // Message to test with.
+  const char *message = "My message is bigger than yours.";
+  const uint8_t *byte_message = reinterpret_cast<const uint8_t *>(message);
+  const uint32_t length = strlen(message) + 1;
+
+  // Make it look like we only wrote part of it on the first try.
+  EXPECT_CALL(mock_serial_, Write(kFd, byte_message + length - 1, 1))
+      .Times(1)
+      .WillOnce(Return(1));
+  EXPECT_CALL(mock_serial_, Write(kFd, byte_message, length))
+      .Times(1)
+      .WillOnce(Return(length - 1));
+
+  EXPECT_TRUE(serial_.SendMessage(byte_message, length));
+}
+
+// Tests that SendMessage handles a write failure.
+TEST_F(SerialLinkTest, SendMessageWriteFailureTest) {
+  OpenSerial();
+
+  // Message to test with.
+  const char *message = "poptart";
+  const uint8_t *byte_message = reinterpret_cast<const uint8_t *>(message);
+  const uint32_t length = strlen(message) + 1;
+
+  // Make it look like writing the message failed.
+  EXPECT_CALL(mock_serial_, Write(kFd, byte_message, length))
+      .Times(1)
+      .WillOnce(Return(-1));
+
+  // Sending the message should fail now.
+  EXPECT_FALSE(serial_.SendMessage(byte_message, length));
+}
+
+// Tests that ReceiveMessage works under normal conditions.
+TEST_F(SerialLinkTest, ReceiveMessageTest) {
+  OpenSerial();
+
+  // Message to test with.
+  const char *expected_message = "poptart";
+  const uint32_t length = strlen(expected_message) + 1;
+  uint8_t message[length];
+  const uint8_t *byte_ex_message =
+      reinterpret_cast<const uint8_t *>(expected_message);
+
+  // Make it look like writing succeeded on the first try.
+  EXPECT_CALL(mock_serial_, Read(kFd, message, length))
+      .Times(1)
+      .WillOnce(
+          DoAll(SetArrayArgument<1>(byte_ex_message, byte_ex_message + length),
+          Return(length)));
+
+  EXPECT_TRUE(serial_.ReceiveMessage(message, length));
+
+  // Make sure the messages match.
+  EXPECT_EQ(0,
+            strcmp(expected_message, reinterpret_cast<const char *>(message)));
+}
+
+// Tests that ReceiveMessage works when it has to split the message up into parts.
+TEST_F(SerialLinkTest, ReceiveMessageSplitTest) {
+  OpenSerial();
+
+  // Message to test with.
+  const char *expected_message = "My message is bigger than yours.";
+  const uint32_t length = strlen(expected_message) + 1;
+  uint8_t message[length];
+  const uint8_t *byte_ex_message =
+      reinterpret_cast<const uint8_t *>(expected_message);
+
+  // Make it look like we only read part of it on the first try.
+  EXPECT_CALL(mock_serial_, Read(kFd, message + length - 1, 1))
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<1>(byte_ex_message + length - 1,
+                                          byte_ex_message + length),
+                      Return(1)));
+  EXPECT_CALL(mock_serial_, Read(kFd, message, length))
+      .Times(1)
+      .WillOnce(DoAll(
+          SetArrayArgument<1>(byte_ex_message, byte_ex_message + length - 1),
+          Return(length - 1)));
+
+  EXPECT_TRUE(serial_.ReceiveMessage(message, length));
+
+  // Make sure the messages match.
+  EXPECT_EQ(0,
+            strcmp(expected_message, reinterpret_cast<const char *>(message)));
+}
+
+// Tests that ReceiveMessage handles a read failure.
+TEST_F(SerialLinkTest, SendMessageReadFailureTest) {
+  OpenSerial();
+
+  // Message to test with.
+  const uint32_t length = 32;
+  uint8_t message[length];
+
+  // Make it look like reading the message failed.
+  EXPECT_CALL(mock_serial_, Read(kFd, message, length))
+      .Times(1)
+      .WillOnce(Return(-1));
+
+  // Receiving the message should fail now.
+  EXPECT_FALSE(serial_.ReceiveMessage(message, length));
+}
+
+int main(int argc, char **argv) {
+  // Initialize GoogleMock.
+  ::testing::InitGoogleMock(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace testing
+}  // namespace sim
+}  // namespace libmc

--- a/apps/libmc/sim/tests/simulator_com_test.cc
+++ b/apps/libmc/sim/tests/simulator_com_test.cc
@@ -1,0 +1,501 @@
+#include <stdint.h>
+#include <string.h>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "apps/libmc/constants.h"
+#include "apps/libmc/sim/protobuf/test.pb.h"
+#include "apps/libmc/sim/simulator_com.h"
+#include "mock_cows.h"
+#include "mock_serial_link.h"
+
+namespace libmc {
+namespace sim {
+namespace testing {
+namespace {
+
+// Special matcher for verifying that a binary message sent over the wire is
+// valid.
+// Args:
+//  message: The expected message to compare to.
+//  length: The expected length of the message, including the initial overhead
+//          and zero separator.
+MATCHER_P2(BinMessageValid, message, length, "") {
+  // Make sure that it has the trailing zeros.
+  if (arg[length - 2] != 0) {
+    *result_listener << "where the penultimate byte is not zero.";
+    return false;
+  }
+  if (arg[length - 1] != 0) {
+    *result_listener << "where the last byte is not zero.";
+    return false;
+  }
+
+  // Try deserializing the message, and make sure that it matches.
+  TestMessage got_message;
+  if (!got_message.ParseFromArray(arg + 2, length - 4)) {
+    *result_listener << "where parsing the message failed.";
+    return false;
+  }
+  if (got_message.field1() != message.field1()) {
+    *result_listener << "where field1 is " << got_message.field1()
+                     << " and not " << message.field1();
+    return false;
+  }
+  if (got_message.field2() != message.field2()) {
+    *result_listener << "where field2 is " << got_message.field2()
+                     << " and not " << message.field2();
+    return false;
+  }
+
+  return true;
+}
+
+// Packet separator value.
+const uint8_t kSeparator[] = {0, 0};
+
+}
+
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArrayArgument;
+using ::testing::StrEq;
+using ::testing::StrictMock;
+using ::testing::_;
+
+// Tests for the SimulatorCom class.
+class SimulatorComTest : public ::testing::Test {
+ protected:
+  // Inject the mock dependencies.
+  SimulatorComTest() : com_(&mock_serial_, &mock_cows_) {}
+
+  // Makes it look like synchronizing to the beginning of a packet worked.
+  void SetUpPacketSync() {
+    // Make it look like we received the separator.
+    EXPECT_CALL(mock_serial_, ReceiveMessage(_, 2))
+        .Times(1)
+        .WillOnce(DoAll(SetArrayArgument<0>(kSeparator, kSeparator + 2),
+                        Return(true)));
+  }
+
+  // Mock dependencies.
+  StrictMock<MockSerialLink> mock_serial_;
+  StrictMock<MockCows> mock_cows_;
+
+  // SimulatorCom class to use for testing.
+  SimulatorCom com_;
+};
+
+// Tests that Open works under normal conditions.
+TEST_F(SimulatorComTest, OpenTest) {
+  // Set up the mock to look like opening the serial link succeeded.
+  EXPECT_CALL(mock_serial_, Open(StrEq(constants::kSimulator.Device),
+                                 constants::kSimulator.BaudRate))
+      .Times(1)
+      .WillOnce(Return(true));
+  // Make it look like sending the initial separator also succeeded.
+  EXPECT_CALL(mock_serial_, SendMessage(_, 2)).Times(1).WillOnce(Return(true));
+
+  // Perform the call to Open, which should work.
+  EXPECT_TRUE(com_.Open());
+}
+
+// Tests that Open handles a SerialLink failure.
+TEST_F(SimulatorComTest, OpenSerialLinkFailureTest) {
+  // Set up the mock to look like opening the serial link failed.
+  EXPECT_CALL(mock_serial_, Open(StrEq(constants::kSimulator.Device),
+                                 constants::kSimulator.BaudRate))
+      .Times(2)
+      .WillOnce(Return(false))
+      .WillOnce(Return(true));
+  // Make it look like sending the initial separator also failed.
+  EXPECT_CALL(mock_serial_, SendMessage(_, 2)).Times(1).WillOnce(Return(false));
+
+  // Perform the calls to Open, which should fail twice.
+  EXPECT_FALSE(com_.Open());
+  EXPECT_FALSE(com_.Open());
+}
+
+// Tests that SendMessage works under normal conditions.
+TEST_F(SimulatorComTest, SendMessageTest) {
+  // Create a test message.
+  TestMessage test_message;
+  test_message.set_field1(42);
+  test_message.set_field2(true);
+
+  const uint32_t message_length = test_message.ByteSizeLong();
+  const uint32_t cows_length = message_length + 4;
+  const uint32_t padded_length = cows_length + cows_length % 2;
+
+  // Set up expectations for COWS stuffing.
+  EXPECT_CALL(mock_cows_, CowsStuff(_, padded_length / 2)).Times(1);
+  // It should also send the message over serial.
+  EXPECT_CALL(
+      mock_serial_,
+      SendMessage(BinMessageValid(test_message, cows_length), cows_length))
+      .Times(1)
+      .WillOnce(Return(true));
+
+  EXPECT_TRUE(com_.SendMessage(test_message));
+}
+
+// Tests that SendMessage handles a failure to send the message.
+TEST_F(SimulatorComTest, SendMessageFailureTest) {
+  // Create a test message.
+  TestMessage test_message;
+  test_message.set_field1(42);
+  test_message.set_field2(true);
+
+  const uint32_t message_length = test_message.ByteSizeLong();
+  const uint32_t cows_length = message_length + 4;
+  const uint32_t padded_length = cows_length + cows_length % 2;
+
+  // Set up expectations for COWS stuffing.
+  EXPECT_CALL(mock_cows_, CowsStuff(_, padded_length / 2)).Times(1);
+  // It should fail to send the message over serial.
+  EXPECT_CALL(
+      mock_serial_,
+      SendMessage(BinMessageValid(test_message, cows_length), cows_length))
+      .Times(1)
+      .WillOnce(Return(false));
+
+  EXPECT_FALSE(com_.SendMessage(test_message));
+}
+
+// Tests that we can receive a message under normal conditions.
+TEST_F(SimulatorComTest, ReceiveMessageTest) {
+  SetUpPacketSync();
+
+  // Create a fake packet to use for this test.
+  TestMessage message;
+  message.set_field1(42);
+  message.set_field2(true);
+
+  const uint32_t message_length = message.ByteSizeLong();
+  const uint32_t cows_length = message_length + 4;
+  const uint32_t padded_length = cows_length + cows_length % 2;
+
+  uint8_t *unstuffed_packet = new uint8_t[padded_length];
+  ASSERT_TRUE(message.SerializeToArray(unstuffed_packet + 2, message_length));
+
+  // Create a fake packet that looks like it could be a stuffed version of the
+  // real one. It never actually tries to read the packet without un-stuffing
+  // it, so we can get away with this as long as we have the zero separator and
+  // no zeros in the middle.
+  uint8_t *packet = new uint8_t[padded_length];
+  memset(packet, 1, cows_length - 2);
+  memset(packet + cows_length - 2, 0, 2);
+
+  // Make ReceivePartialMessage produce this packet.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  EXPECT_CALL(mock_serial_, ReceivePartialMessage(_, max_length))
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<0>(packet, packet + cows_length),
+                      Return(cows_length)));
+  // Expect a call to CowsUnstuff. Instead of actually unstuffing the packet,
+  // we're going to cheat and substitute our already unstuffed one.
+  uint16_t *word_packet = reinterpret_cast<uint16_t *>(unstuffed_packet);
+  // We lose one word on the length, because we don't want to parse the
+  // separator.
+  EXPECT_CALL(mock_cows_, CowsUnstuff(_, padded_length / 2 - 1))
+      .Times(1)
+      .WillOnce(SetArrayArgument<0>(word_packet,
+                                    word_packet + padded_length / 2 - 1));
+
+  TestMessage got_message;
+  EXPECT_TRUE(com_.ReceiveMessage(&got_message));
+
+  // Make sure the message we got matches the one we sent.
+  EXPECT_EQ(message.field1(), got_message.field1());
+  EXPECT_EQ(message.field2(), got_message.field2());
+
+  delete[] packet;
+  delete[] unstuffed_packet;
+}
+
+// Tests that we can receive a message when it's split into multiple parts.
+TEST_F(SimulatorComTest, ReceiveSplitMessageTest) {
+  SetUpPacketSync();
+
+  // Create a fake packet to use for this test.
+  TestMessage message;
+  message.set_field1(42);
+  message.set_field2(true);
+
+  const uint32_t message_length = message.ByteSizeLong();
+  const uint32_t cows_length = message_length + 4;
+  const uint32_t padded_length = cows_length + cows_length % 2;
+
+  uint8_t *unstuffed_packet = new uint8_t[padded_length];
+  ASSERT_TRUE(message.SerializeToArray(unstuffed_packet + 2, message_length));
+
+  // Create a fake packet that looks like it could be a stuffed version of the
+  // real one. It never actually tries to read the packet without un-stuffing
+  // it, so we can get away with this as long as we have the zero separator and
+  // no zeros in the middle.
+  uint8_t *packet = new uint8_t[padded_length];
+  memset(packet, 1, cows_length - 2);
+  memset(packet + cows_length - 2, 0, 2);
+
+  // Make ReceivePartialMessage produce this packet, but over the course of two
+  // calls.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  EXPECT_CALL(mock_serial_,
+              ReceivePartialMessage(_, max_length - cows_length + 1))
+      .Times(1)
+      .WillOnce(DoAll(
+          SetArrayArgument<0>(packet + cows_length - 1, packet + cows_length),
+          Return(1)));
+  EXPECT_CALL(mock_serial_, ReceivePartialMessage(_, max_length))
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<0>(packet, packet + cows_length - 1),
+                      Return(cows_length - 1)));
+  // Expect a call to CowsUnstuff. Instead of actually unstuffing the packet,
+  // we're going to cheat and substitute our already unstuffed one.
+  uint16_t *word_packet = reinterpret_cast<uint16_t *>(unstuffed_packet);
+  // We lose one word on the length, because we don't want to parse the
+  // separator.
+  EXPECT_CALL(mock_cows_, CowsUnstuff(_, padded_length / 2 - 1))
+      .Times(1)
+      .WillOnce(SetArrayArgument<0>(word_packet,
+                                    word_packet + padded_length / 2 - 1));
+
+  TestMessage got_message;
+  EXPECT_TRUE(com_.ReceiveMessage(&got_message));
+
+  // Make sure the message we got matches the one we sent.
+  EXPECT_EQ(message.field1(), got_message.field1());
+  EXPECT_EQ(message.field2(), got_message.field2());
+
+  delete[] packet;
+  delete[] unstuffed_packet;
+}
+
+// Tests that we can receive multiple messages in sequence.
+TEST_F(SimulatorComTest, ReceiveMessageMultiMessageTest) {
+  SetUpPacketSync();
+
+  // Create a fake packets to use for this test.
+  TestMessage message1;
+  message1.set_field1(42);
+  message1.set_field2(true);
+
+  TestMessage message2;
+  message2.set_field1(30);
+  message2.set_field2(false);
+
+  const uint32_t message1_length = message1.ByteSizeLong();
+  const uint32_t cows_length1 = message1_length + 4;
+  const uint32_t padded_length1 = cows_length1 + cows_length1 % 2;
+  const uint32_t message2_length = message2.ByteSizeLong();
+  const uint32_t cows_length2 = message2_length + 4;
+  const uint32_t padded_length2 = cows_length2 + cows_length2 % 2;
+
+  uint8_t *unstuffed_packet1 = new uint8_t[padded_length1];
+  uint8_t *unstuffed_packet2 = new uint8_t[padded_length2];
+  ASSERT_TRUE(message1.SerializeToArray(unstuffed_packet1 + 2, message1_length));
+  ASSERT_TRUE(message2.SerializeToArray(unstuffed_packet2 + 2, message2_length));
+
+  // Create fake packets that looks like stuffed versions of the
+  // real ones. It never actually tries to read the packet without un-stuffing
+  // it, so we can get away with this as long as we have the zero separator and
+  // no zeros in the middle.
+  uint8_t *packets = new uint8_t[padded_length1 + padded_length2];
+  memset(packets, 1, padded_length1 + padded_length2);
+  memset(packets + cows_length1 - 2, 0, 2);
+  memset(packets + cows_length1 + cows_length2 - 2, 0, 2);
+
+  // Make ReceivePartialMessage produce this packet stream, but not broken up
+  // neatly.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  const uint32_t stream_length = cows_length1 + cows_length2;
+  EXPECT_CALL(mock_serial_,
+              ReceivePartialMessage(_, max_length - cows_length2 + 1))
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<0>(packets + stream_length - 1,
+                                          packets + stream_length),
+                      Return(1)));
+  EXPECT_CALL(mock_serial_, ReceivePartialMessage(_, max_length))
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<0>(packets, packets + stream_length - 1),
+                      Return(stream_length - 1)));
+  // Expect calls to CowsUnstuff. Instead of actually unstuffing the packets,
+  // we're going to cheat and substitute our already unstuffed ones.
+  uint16_t *word_packet1 = reinterpret_cast<uint16_t *>(unstuffed_packet1);
+  uint16_t *word_packet2 = reinterpret_cast<uint16_t *>(unstuffed_packet2);
+  // We lose one word on the length, because we don't want to parse the
+  // separator.
+  EXPECT_CALL(mock_cows_, CowsUnstuff(_, padded_length2 / 2 - 1))
+      .Times(1)
+      .WillOnce(SetArrayArgument<0>(word_packet2,
+                                    word_packet2 + padded_length2 / 2 - 1));
+  EXPECT_CALL(mock_cows_, CowsUnstuff(_, padded_length1 / 2 - 1))
+      .Times(1)
+      .WillOnce(SetArrayArgument<0>(word_packet1,
+                                    word_packet1 + padded_length1 / 2 - 1));
+
+  TestMessage got_message1, got_message2;
+  EXPECT_TRUE(com_.ReceiveMessage(&got_message1));
+  EXPECT_TRUE(com_.ReceiveMessage(&got_message2));
+
+  // Make sure the messages we got match the ones we sent.
+  EXPECT_EQ(message1.field1(), got_message1.field1());
+  EXPECT_EQ(message1.field2(), got_message1.field2());
+  EXPECT_EQ(message2.field1(), got_message2.field1());
+  EXPECT_EQ(message2.field2(), got_message2.field2());
+
+  delete[] packets;
+  delete[] unstuffed_packet1;
+  delete[] unstuffed_packet2;
+}
+
+// Tests that we can parse multiple messages when they are received in one burst.
+TEST_F(SimulatorComTest, ReceiveMessageBlockTest) {
+  SetUpPacketSync();
+
+  // Create a fake packets to use for this test.
+  TestMessage message1;
+  message1.set_field1(42);
+  message1.set_field2(true);
+
+  TestMessage message2;
+  message2.set_field1(30);
+  message2.set_field2(false);
+
+  const uint32_t message1_length = message1.ByteSizeLong();
+  const uint32_t cows_length1 = message1_length + 4;
+  const uint32_t padded_length1 = cows_length1 + cows_length1 % 2;
+  const uint32_t message2_length = message2.ByteSizeLong();
+  const uint32_t cows_length2 = message2_length + 4;
+  const uint32_t padded_length2 = cows_length2 + cows_length2 % 2;
+
+  uint8_t *unstuffed_packet1 = new uint8_t[padded_length1];
+  uint8_t *unstuffed_packet2 = new uint8_t[padded_length2];
+  ASSERT_TRUE(message1.SerializeToArray(unstuffed_packet1 + 2, message1_length));
+  ASSERT_TRUE(message2.SerializeToArray(unstuffed_packet2 + 2, message2_length));
+
+  // Create fake packets that looks like stuffed versions of the
+  // real ones. It never actually tries to read the packet without un-stuffing
+  // it, so we can get away with this as long as we have the zero separator and
+  // no zeros in the middle.
+  uint8_t *packets = new uint8_t[padded_length1 + padded_length2];
+  memset(packets, 1, padded_length1 + padded_length2);
+  memset(packets + cows_length1 - 2, 0, 2);
+  memset(packets + cows_length1 + cows_length2 - 2, 0, 2);
+
+  // Make ReceivePartialMessage produce this packet stream.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  const uint32_t stream_length = cows_length1 + cows_length2;
+  EXPECT_CALL(mock_serial_, ReceivePartialMessage(_, max_length))
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<0>(packets, packets + stream_length),
+                      Return(stream_length)));
+  // Expect calls to CowsUnstuff. Instead of actually unstuffing the packets,
+  // we're going to cheat and substitute our already unstuffed ones.
+  uint16_t *word_packet1 = reinterpret_cast<uint16_t *>(unstuffed_packet1);
+  uint16_t *word_packet2 = reinterpret_cast<uint16_t *>(unstuffed_packet2);
+  // We lose one word on the length, because we don't want to parse the
+  // separator.
+  EXPECT_CALL(mock_cows_, CowsUnstuff(_, padded_length2 / 2 - 1))
+      .Times(1)
+      .WillOnce(SetArrayArgument<0>(word_packet2,
+                                    word_packet2 + padded_length2 / 2 - 1));
+  EXPECT_CALL(mock_cows_, CowsUnstuff(_, padded_length1 / 2 - 1))
+      .Times(1)
+      .WillOnce(SetArrayArgument<0>(word_packet1,
+                                    word_packet1 + padded_length1 / 2 - 1));
+
+  TestMessage got_message1, got_message2;
+  EXPECT_TRUE(com_.ReceiveMessage(&got_message1));
+  EXPECT_TRUE(com_.ReceiveMessage(&got_message2));
+
+  // Make sure the messages we got match the ones we sent.
+  EXPECT_EQ(message1.field1(), got_message1.field1());
+  EXPECT_EQ(message1.field2(), got_message1.field2());
+  EXPECT_EQ(message2.field1(), got_message2.field1());
+  EXPECT_EQ(message2.field2(), got_message2.field2());
+
+  delete[] packets;
+  delete[] unstuffed_packet1;
+  delete[] unstuffed_packet2;
+}
+
+// Tests that ReceiveMessage handles a packet that's too long.
+TEST_F(SimulatorComTest, ReceiveMessageTooLongTest) {
+  SetUpPacketSync();
+
+  // Create a fake packet that deliberately doesn't have a separator.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  uint8_t *packet = new uint8_t[max_length];
+  memset(packet, 1, max_length);
+
+  // Make ReceivePartialMessage produce this packet.
+  EXPECT_CALL(mock_serial_, ReceivePartialMessage(_, max_length))
+      .Times(1)
+      .WillOnce(DoAll(SetArrayArgument<0>(packet, packet + max_length),
+                      Return(max_length)));
+
+  // It should fail to receive this message.
+  TestMessage message;
+  EXPECT_FALSE(com_.ReceiveMessage(&message));
+
+  delete[] packet;
+}
+
+// Tests that ReceiveMessage handles a reading failure.
+TEST_F(SimulatorComTest, ReceiveMessageReadFailureTest) {
+  SetUpPacketSync();
+
+  // Make ReceivePartialMessage look like it failed.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  EXPECT_CALL(mock_serial_, ReceivePartialMessage(_, max_length))
+      .Times(1)
+      .WillOnce(Return(-1));
+
+  // It should fail to receive a message.
+  TestMessage message;
+  EXPECT_FALSE(com_.ReceiveMessage(&message));
+}
+
+// Tests that SyncToPacket works under normal conditions.
+TEST_F(SimulatorComTest, SyncToPacketTest) {
+  // Make it look like it found the packet on its second try.
+  const uint8_t non_separator[] = {1, 1};
+  EXPECT_CALL(mock_serial_, ReceiveMessage(_, 2))
+      .Times(2)
+      .WillOnce(DoAll(SetArrayArgument<0>(non_separator, non_separator + 2),
+                      Return(true)))
+      .WillOnce(
+          DoAll(SetArrayArgument<0>(kSeparator, kSeparator + 2), Return(true)));
+
+  // For the sake of convenience, we're going to make it look like reading the
+  // actual packet failed, just so we don't have to mock everything.
+  const uint32_t max_length = constants::kSimulator.MaxPacketSize;
+  EXPECT_CALL(mock_serial_, ReceivePartialMessage(_, max_length))
+      .Times(1)
+      .WillOnce(Return(-1));
+
+  // It should fail to receive a message.
+  TestMessage message;
+  EXPECT_FALSE(com_.ReceiveMessage(&message));
+}
+
+// Tests that SyncToPacket handles a read failure.
+TEST_F(SimulatorComTest, SyncToPacketReadFailureTest) {
+  // Make it look like reading failed.
+  EXPECT_CALL(mock_serial_, ReceiveMessage(_, 2))
+      .Times(2)
+      .WillRepeatedly(Return(false));
+
+  // Receiving a packet should fail immediately.
+  TestMessage message;
+  EXPECT_FALSE(com_.ReceiveMessage(&message));
+  // The state should not be updated, so it should go and try to find the packet
+  // start again.
+  EXPECT_FALSE(com_.ReceiveMessage(&message));
+}
+
+}  // namespace testing
+}  // namespace sim
+}  // namespace libmc

--- a/gtest.BUILD
+++ b/gtest.BUILD
@@ -1,0 +1,31 @@
+cc_library(
+  name = "gtest",
+  srcs = glob(
+    ["googletest/src/*.cc"],
+    exclude = ["googletest/src/gtest-all.cc"]
+  ),
+  hdrs = glob([
+    "googletest/include/**/*.h",
+    "googletest/src/*.h"
+  ]),
+  copts = ["-Iexternal/gtest/googletest/include",
+           "-Iexternal/gtest/googletest"],
+  linkopts = ["-pthread"],
+  visibility = ["//visibility:public"],
+)
+
+cc_library(
+  name = "gmock",
+  srcs = glob(
+    ["googlemock/src/*.cc"],
+    exclude = ["googlemock/src/gmock-all.cc"]
+  ),
+  hdrs = glob([
+    "googlemock/include/**/*.h",
+    "googlemock/src/*.h",
+    "googletest/include/**/*.h",
+  ]),
+  copts = ["-Iexternal/gtest/googlemock/include",
+           "-Iexternal/gtest/googletest/include"],
+  visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
The executive summary is that it uses Protobuf to serialize messages passed over the serial link. I will work on the Python side of things shortly.